### PR TITLE
Bugfix for console in IE8

### DIFF
--- a/ClientPrototypes/GolfExample_TCAPI/scripts/TCDriver.js
+++ b/ClientPrototypes/GolfExample_TCAPI/scripts/TCDriver.js
@@ -86,7 +86,7 @@ function XHR_request(lrs, url, method, data, auth, callback, ignore404, extraHea
         ieXDomain = true;
         ieModeRequest = TCDriver_GetIEModeRequest(method, url, headers, data);
         xhr = new XDomainRequest();
-    	if(typeof console !=== 'undefined') {
+    	if(typeof console !== 'undefined') {
 	        console.log(ieModeRequest.method + ", " + ieModeRequest.url);
 	    }
         xhr.open(ieModeRequest.method, ieModeRequest.url);
@@ -145,7 +145,7 @@ function XHR_request(lrs, url, method, data, auth, callback, ignore404, extraHea
 
 
 function TCDriver_Log(str){
-    if(console !=== 'undefined'){
+    if(console !== 'undefined'){
         console.log(str);
     }
 }


### PR DESCRIPTION
Looks like we can't use console.log in IE8 without a typeof wrapper. console was not a proper JavaScript object in the final version of IE8.
