### PR TITLE
fixes to new identifiers prior to release

### DIFF
--- a/JsTetris_TCAPI/TC_tetris.js
+++ b/JsTetris_TCAPI/TC_tetris.js
@@ -128,7 +128,7 @@ function tc_getContext (extensions, parent) {
 
 function tc_getContextExtensions () {
     return {
-        "http://id.tincanapi.com/extension/attemptId": gameId
+        "http://id.tincanapi.com/extension/attempt-id": gameId
     };
 }
 
@@ -231,7 +231,7 @@ function tc_sendStatement_FinishLevel (level, time, apm, lines, score) {
     }
 
     extensions["http://id.tincanapi.com/extension/apm"] = apm;
-    extensions["http://id.tincanapi.com/extension/lines"] = lines;
+    extensions["http://id.tincanapi.com/extension/tetris-lines"] = lines;
 
     tc_sendStatementWithContext(
         {
@@ -276,7 +276,7 @@ function tc_sendStatement_EndGame (level, time, apm, lines, score) {
 
     extensions["http://id.tincanapi.com/extension/level"] = level;
     extensions["http://id.tincanapi.com/extension/apm"] = apm;
-    extensions["http://id.tincanapi.com/extension/lines"] = lines;
+    extensions["http://id.tincanapi.com/extension/tetris-lines"] = lines;
 
     tc_sendStatementWithContext(
         {

--- a/Locator_TCAPI/index.html
+++ b/Locator_TCAPI/index.html
@@ -127,7 +127,7 @@
                     object: {
                         id: pmrk.tc_id,
                         definition: {
-                            type: "http://id.tincanapi.com/activitytype/place",
+                            type: "http://activitystrea.ms/schema/1.0/place",
                             name: {
                                 "en-US": pmrk.name
                             },

--- a/activity-definition-json-snippets.txt
+++ b/activity-definition-json-snippets.txt
@@ -513,7 +513,7 @@ http://id.tincanapi.com/activity/tincan-prototypes/nashville-museums-tour
 
 http://id.tincanapi.com/activity/tincan-prototypes/nashville-museums-tour/parthenon
 {
-    "type": "http://id.tincanapi.com/activitytype/place",
+    "type": "http://activitystrea.ms/schema/1.0/place",
     "name": {
         "en-US": "Parthenon"
     },
@@ -530,7 +530,7 @@ http://id.tincanapi.com/activity/tincan-prototypes/nashville-museums-tour/countr
     "description": {
         "en-US": "The mission of the Country Music Hall of Fame and Museum is to identify and preserve the evolving history and traditions of country music and to educate its audiences. Functioning as a local history museum and as an international arts organization, the Country Music Hall of Fame and Museum serves visiting and non-visiting audiences including fans, students, scholars, members of the music industry."
     },
-    "type": "http://id.tincanapi.com/activitytype/place"
+    "type": "http://activitystrea.ms/schema/1.0/place"
 }
 
 http://id.tincanapi.com/activity/tincan-prototypes/nashville-museums-tour/the-frist
@@ -541,7 +541,7 @@ http://id.tincanapi.com/activity/tincan-prototypes/nashville-museums-tour/the-fr
     "description": {
         "en-US": "The Frist Center opened in April 2001, and since that time has hosted a spectacular array of art from the region, the country, and around the world."
     },
-    "type": "http://id.tincanapi.com/activitytype/place"
+    "type": "http://activitystrea.ms/schema/1.0/place"
 }
 
 http://id.tincanapi.com/activity/tincan-prototypes/nashville-museums-tour/adventure-science-center
@@ -552,7 +552,7 @@ http://id.tincanapi.com/activity/tincan-prototypes/nashville-museums-tour/advent
     "description": {
         "en-US": "Igniting curiosity and inspiring the discovery of science for all ages."
     },
-    "type": "http://id.tincanapi.com/activitytype/place"
+    "type": "http://activitystrea.ms/schema/1.0/place"
 }
 
 http://id.tincanapi.com/activity/tincan-prototypes/nashville-museums-tour/cheekwood
@@ -563,6 +563,6 @@ http://id.tincanapi.com/activity/tincan-prototypes/nashville-museums-tour/cheekw
     "description": {
         "en-US": "Cheekwood is a 55-acre botanical garden and art museum located on the historic Cheek estate. Cheekwood exists to celebrate and preserve its landscape, buildings, art and botanical collections and, through these unique means, provide an inspiring place for visitors to explore their connections with art, nature and the environment."
     },
-    "type": "http://id.tincanapi.com/activitytype/place"
+    "type": "http://activitystrea.ms/schema/1.0/place"
 }
 

--- a/ids-list.md
+++ b/ids-list.md
@@ -153,14 +153,14 @@ Games are attempted and then completed. Game levels are completed.
 All statements within an attempt are grouped together by an attempt Id. Note that the
 registration id stored in Context Registration field may include multiple attempts. 
 
-* http://id.tincanapi.com/extension/attemptId
+* http://id.tincanapi.com/extension/attempt-id
 
 ## Result Extensions
 Each completed game and game level records the actions per minute (apm) and number of lines achieved
 by the player. 
 
 * http://id.tincanapi.com/extension/apm
-* http://id.tincanapi.com/extension/lines
+* http://id.tincanapi.com/extension/tetris-lines
 
 # Locator Prototype
 The locator prototype is an example of a learning activity that takes advantage on native features of a mobile device,
@@ -189,7 +189,7 @@ The activity is a 'performance' type as the learner must perform a series of tas
 
 * http://id.tincanapi.com/activitytype/recipe
 * http://id.tincanapi.com/activitytype/source
-* http://id.tincanapi.com/activitytype/place
+* http://activitystrea.ms/schema/1.0/place
 * http://adlnet.gov/expapi/activities/performance
 
 ##Verbs


### PR DESCRIPTION
In finalising the recipe I picked up one case where I had created a new activity type where one existed and two cases where the IRI awaiting approval in Registry was different to the one used in the prototype. I believe the Registry version was post- @brianjmiller feedback so changed the prototype and recipe to to match. 