### PR TITLE
Add ability to test POST requests via OAuth test page

### DIFF
--- a/OAuthSample/index.html
+++ b/OAuthSample/index.html
@@ -50,10 +50,14 @@
                 <button id="fetchToken">Fetch Token</button>
 
                 <h2>Step 3 - Test Access Token</h2>
+                <h5>Note: Using the POST button, if successful, will result in data being entered into the LRS.</h5>
                 <button id="tryToken">Try Token</button>
+                <button id="tryTokenPost">Try Token (POST)</button>
 
                 <h2>Step 4 - Test No-User Token</h2>
+                <h5>Note: Using the POST button, if successful, will result in data being entered into the LRS.</h5>
                 <button id="tryNoUserToken">Try No-User Token</button>
+                <button id="tryNoUserTokenPost">Try No-User Token (POST)</button>
 
             </td><td id="userLogArea">
                 <ul id="userLog"></ul>

--- a/OAuthSample/oauthTest.js
+++ b/OAuthSample/oauthTest.js
@@ -191,7 +191,7 @@
                     self._userLog("Successfully issued GET request on " +
                         "/statements resource with (no user) OAuth credentials!");
                 } else {
-                    self._error("OAuth statements resource with (no user) request failed");
+                    self._error("OAuth signed statements request failed");
                 }
             });
         },


### PR DESCRIPTION
Mostly copy and past of the GET stuff with the addition of a JSON object statement to use when as the POST body.
Added an application/json header for all requests, doesn't affect GETs and POSTs require it