### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-###Overview
+### Overview
 
 This repo contains client prototypes for the Tin Can API.
 
@@ -9,7 +9,7 @@ This repo contains client prototypes for the Tin Can API.
 * StatementViewer: statement stream viewer with rudimentary query ability
 * OAuthSample: simple page for testing the OAuth compatibility of a Tin Can endpoint
 
-###Installation
+### Installation
 
 Make sure to fetch all the code dependencies by running ```git submodule update --init --recursive```
 
@@ -20,7 +20,7 @@ Make sure to fetch all the code dependencies by running ```git submodule update 
 	* You should then see: [], or JSON of a statement if statements have already been stored for this LRS.
 * Load `index.html` in a browser
 
-###Contact:
+### Contact:
 
 info@tincanapi.com<br>
 http://tincanapi.com/

--- a/ids-list.md
+++ b/ids-list.md
@@ -4,12 +4,12 @@ The launcher prototype simulates the role of an LMS in launching activities. It
 issues an 'experienced' statement when the learner accesses the page and a
 'launched' statement for each activity when launched.
 
-##Recipe
+## Recipe
 All statements include the Recipe ID in the 'category' context activity list.
 
 * http://id.tincanapi.com/recipe/tincan-prototypes/launcher/1
 
-##Activities
+## Activities
 Statements are grouped in the context of ```http://id.tincanapi.com/activity/tincan-prototypes```. They are 
 categorized in the context of ```http://id.tincanapi.com/recipe/tincan-prototypes/golf/1``` and 
 ```http://id.tincanapi.com/activity/tincan-prototypes/launcher``` .


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
